### PR TITLE
README: re-wrote build instructions, using pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,28 @@ _How to build the full toolchain from scratch_
 Install Prerequisites
 ---------------------
 
-On Debian and Ubuntu, you will want to install these packages:
+### Ubuntu 12.04
+
+Toolchain requires multiple dependencies, including
+[zerovm-zmq-dev](http://github.com/zerovm/zerovm). To install `zerovm-zmq-dev`,
+first choose from one of the following PPAs:
+
+- Latest: [ppa:zerovm-ci/zerovm-latest](https://launchpad.net/~zerovm-ci/+archive/zerovm-latest)
+- Stable: [ppa:zerovm-ci/zerovm-stable](https://launchpad.net/~zerovm-ci/+archive/zerovm-stable)
+
+Add the PPA to your sources list:
+
+    sudo apt-get install python-software-properties
+    sudo add-apt-reposistory ppa:zerovm-ci/zerovm-latest
+    # or 'sudo add-apt-repository ppa:zerovm-ci/zerovm-stable'
+    sudo apt-get update
+
+Install dependencies:
 
     sudo apt-get install libc6-dev-i386 libglib2.0-dev pkg-config git \
         build-essential automake autoconf libtool g++-multilib texinfo \
-        flex bison groff gperf texinfo subversion
-
-Install ZeroMQ version 4.0.1 or greater. You can either install it
-through these packages:
-
-    http://packages.zerovm.org/apt/ubuntu/pool/main/z/zeromq3/libzmq3_4.0.1-ubuntu1_amd64.deb
-    http://packages.zerovm.org/apt/ubuntu/pool/main/z/zeromq3/libzmq3-dev_4.0.1-ubuntu1_amd64.deb
-
-or you can install it manually (don't forget to `sudo ldconfig`
-after install) by following the
-[ZeroMQ installation guide](http://zeromq.org/area:download).
+        flex bison groff gperf texinfo subversion \
+        zerovm-zmq-dev
 
 Setup Environment Variables
 ----------------------------
@@ -30,22 +37,22 @@ Setup Environment Variables
 You need to set them up prior to building anything. We'll use the
 following variables:
 
-* `ZEROVM_ROOT`: should point to git clone of `zerovm` repository
 * `ZVM_PREFIX`: should point to an *empty writable directory* all
     files will be installed here after `make install`
 * `ZRT_ROOT`: should point to git clone of `zrt` repository
+* `LD_LIBRARY_PATH`: library path for libvalidator.so (from
+  [zvm-validator](https://github.com/zerovm/validator))
+* `CPATH`: include directory containing `zvm.h` (from `zerovm-zmq-dev`)
 
 We will use these values for this guide:
 
-    export ZEROVM_ROOT=$HOME/zerovm
     export ZVM_PREFIX=$HOME/zvm-root
     export ZRT_ROOT=$HOME/zrt
+    export LD_LIBRARY_PATH=/usr/lib64
+    export CPATH=/usr/x86_64-nacl/include
 
 Clone Things
 ------------
-
-    git clone https://github.com/zerovm/validator.git $HOME/validator
-    git clone https://github.com/zerovm/zerovm.git $ZEROVM_ROOT
 
     git clone https://github.com/zerovm/zrt.git $ZRT_ROOT
 
@@ -57,32 +64,11 @@ Clone Things
     git clone https://github.com/zerovm/newlib.git
     git clone https://github.com/zerovm/binutils.git
 
-Build Validator
----------------
-
-    cd $HOME/validator
-    make validator
-    make install PREFIX=$ZVM_PREFIX
-
-A library was installed in `$ZVM_PREFIX/lib64`, so you will want to set
-`LD_LIBRARY_PATH` or install the library globally. We'll just continue
-with the library path set:
-
-    export LD_LIBRARY_PATH=$ZVM_PREFIX/lib64
-
-Build ZeroVM
-------------
-
-    cd $ZEROVM_ROOT
-    LIBRARY_PATH=$ZVM_PREFIX/lib64 make all install PREFIX=$ZVM_PREFIX
-    
-You will need to add `LIBRARY_PATH` if you have installed validator into `$ZVM_PREFIX`, see above.
-
 Build Toolchain
 ---------------
 
     cd $HOME/zvm-toolchain
-    make -j8
+    make -j8 ZEROVM=`which zerovm`  # e.g., '/usr/bin/zerovm'
 
 If something goes wrong you will need to *delete* everything
 (apart from zerovm and validator) in the $ZVM_PREFIX directory and
@@ -94,15 +80,9 @@ Example of cleanup procedures:
     cd $HOME/zvm-toolchain
     make clean
     cd $ZVM_PREFIX
-    rm -fr *
+    rm -rf *
     cd $ZEROVM_ROOT
     make install PREFIX=$ZVM_PREFIX
-
-Now you can run zerovm tests
-
-    export PATH=$ZVM_PREFIX/bin:$PATH
-    cd $ZEROVM_ROOT
-    ./ftests.sh
 
 Install Debugger
 ----------------


### PR DESCRIPTION
README: re-wrote build instructions, using pkgs

Completely re-wrote and simplified the build instructions. The new
instructions involve installation zerovm and zvm-validator from
packages, instead of installing manually.

NOTE: I removed the section which instructs the user to run zerovm tests
by invoking `./ftests.sh` from the ZEROVM_ROOT. We need to figure out a
good context in which to run these tests. They do require a working
toolchain to function, but they are part of the zerovm repo (which is a
prerequisite for building the toolchain), so there's kind of a catch 22
here that we need to think about. Perhaps it's best to move these tests
to the toolchain repo.
